### PR TITLE
feat: enhance Vector MSK sink configuration for better performance an…

### DIFF
--- a/src/ingestion/alb-nginx-vector/docker/vector/config/vector-msk-batch.toml
+++ b/src/ingestion/alb-nginx-vector/docker/vector/config/vector-msk-batch.toml
@@ -4,11 +4,14 @@
 type = "kafka"
 inputs =  ["json_parser"]   
 bootstrap_servers = "%%AWS_MSK_BROKERS%%"
-#key_field = "ip"
+key_field = "meta.ctime"
 topic = "%%AWS_MSK_TOPIC%%"
 compression = "none"
-batch.max_events = 1000
+batch.max_events = 5000
 batch.timeout_secs = 3
+buffer.type = "disk"
+buffer.max_size = 107374182400
+buffer.when_full = "block"
 acknowledgements.enabled = false
   [sinks.msk_sink.encoding]
   codec = "json"


### PR DESCRIPTION
…d reliability

- Enable key_field with meta.ctime for better message partitioning
- Increase batch.max_events from 1000 to 5000 for higher throughput
- Add disk buffer configuration with 100GB capacity for fault tolerance
- Set buffer to block when full to prevent data loss during MSK outages