### PR TITLE
fix: correct JSON configuration formatting in Iceberg connector script

### DIFF
--- a/src/msk-iceberg/create-s3-iceberg-connector-optimized.sh
+++ b/src/msk-iceberg/create-s3-iceberg-connector-optimized.sh
@@ -551,8 +551,8 @@ if [ -z "$CONNECTOR_ARN" ] || [ "$CONNECTOR_ARN" = "None" ]; then
         # Use kafka_time: add insertTS transform, remove timestampConverter
         TRANSFORMS_CONFIG='"transforms": "insertTS,flatten",'
         INSERTTS_CONFIG='"transforms.insertTS.type": "org.apache.kafka.connect.transforms.InsertField$Value",
-        "transforms.insertTS.timestamp.field": "messageTS",'
-        "iceberg.tables.default-partition-by": "day(messageTS)",
+        "transforms.insertTS.timestamp.field": "messageTS",
+        "iceberg.tables.default-partition-by": "day(messageTS)",'
         TIMESTAMP_CONVERTER_CONFIG=""
         echo "Using kafka_time configuration: insertTS transform enabled, timestampConverter disabled"
     else


### PR DESCRIPTION
- Fix missing comma in transforms.insertTS.timestamp.field configuration
- Ensure proper JSON syntax for iceberg.tables.default-partition-by setting
- Resolves configuration parsing issues in MSK connector setup