### PR TITLE
feat(vector): update kafka key field to use meta.ctime

### DIFF
--- a/src/ingestion/alb-nginx-vector/docker/vector/config/vector-msk-ack.toml
+++ b/src/ingestion/alb-nginx-vector/docker/vector/config/vector-msk-ack.toml
@@ -4,7 +4,7 @@
 type = "kafka"
 inputs =  ["json_parser"]   
 bootstrap_servers = "%%AWS_MSK_BROKERS%%"
-#key_field = "ip"
+key_field = "meta.ctime"
 topic = "%%AWS_MSK_TOPIC%%"
 compression = "none"
 acknowledgements.enabled = true


### PR DESCRIPTION
- Change key_field from commented 'ip' to 'meta.ctime' in vector-msk-ack.toml
- Improves message partitioning strategy for better data distribution
- Enhances ALB + Nginx + Vector solution performance